### PR TITLE
fix(memoized-task): now canceled tasks are automatically retried

### DIFF
--- a/addon/tsconfig.json
+++ b/addon/tsconfig.json
@@ -6,6 +6,7 @@
     "paths": {
       "ember-resource-tasks": ["."],
       "ember-resource-tasks/*": ["./*"],
+      "@ember/destroyable": ["node_modules/ember-destroyable-polyfill"],
       "*": ["../types"]
     }
   },

--- a/addon/tsconfig.json
+++ b/addon/tsconfig.json
@@ -6,7 +6,6 @@
     "paths": {
       "ember-resource-tasks": ["."],
       "ember-resource-tasks/*": ["./*"],
-      "@ember/destroyable": ["node_modules/ember-destroyable-polyfill"],
       "*": ["../types"]
     }
   },

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@types/ember__component": "^3.16.4",
     "@types/ember__controller": "^3.16.4",
     "@types/ember__debug": "^3.16.3",
+    "@types/ember__destroyable": "^3.22.0",
     "@types/ember__engine": "^3.16.2",
     "@types/ember__error": "^3.16.1",
     "@types/ember__object": "^3.12.3",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ember-concurrency-decorators": "^2.0.3",
     "ember-concurrency-ts": "^0.2.2",
     "ember-could-get-used-to-this": "^1.0.1",
+    "ember-destroyable-polyfill": "^2.0.3",
     "ember-test-waiters": "^2.1.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5385,7 +5385,7 @@ debug@~4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -8392,7 +8392,7 @@ import-lazy@^2.1.0:
   resolved "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
   integrity sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -9575,11 +9575,6 @@ lodash._baseflatten@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -9588,15 +9583,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*, lodash._bindcallback@^3.0.0:
+lodash._bindcallback@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
 
 lodash._createassigner@^3.0.0:
   version "3.1.1"
@@ -9607,19 +9597,12 @@ lodash._createassigner@^3.0.0:
     lodash._isiterateecall "^3.0.0"
     lodash.restparam "^3.0.0"
 
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -9757,7 +9740,7 @@ lodash.omit@^4.1.0:
   resolved "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
   integrity sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=
 
-lodash.restparam@*, lodash.restparam@^3.0.0:
+lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
   integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=

--- a/yarn.lock
+++ b/yarn.lock
@@ -1763,6 +1763,11 @@
     "@types/ember__engine" "*"
     "@types/ember__object" "*"
 
+"@types/ember__destroyable@^3.22.0":
+  version "3.22.0"
+  resolved "https://registry.npmjs.org/@types/ember__destroyable/-/ember__destroyable-3.22.0.tgz#2af2c27f5d8996694c3f0fe906e2536b2e4c5aca"
+  integrity sha512-T5wZGK1MwEelNIv1bbAvRQZPo9zvfjpGyyFPwjz+sakjImKVcQzb/yq1SgGyT0QTAQAT7l0L+kFru9+fSVVo5A==
+
 "@types/ember__engine@*", "@types/ember__engine@^3.16.2":
   version "3.16.2"
   resolved "https://registry.npmjs.org/@types/ember__engine/-/ember__engine-3.16.2.tgz#886e916b0bb0d417bfeee1db3a3b3fc4591e24ad"


### PR DESCRIPTION
A canceled task could occur if your component is torn down before the
task completes. For long running tasks (such as those network-bound),
this can be a big problem, because the task will become cached, and
the next time a component is mounted that wants to access that same
network resource, no remote request would occur because the canceled
task was cached.

Now, canceled tasks bust the cache, allowing quick navigations or
quick remounts to correctly re-fetch network resources (or whatever
the long running async task is)